### PR TITLE
Add missing commas to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,16 +12,16 @@ setup(name='mb_modelbase',
       install_requires=[
           'anytree', #84 requires scipy==1.2, https://github.com/lumen-org/modelbase/issues/84
           'astropy',
-          'Cython'
+          'Cython',
           'dill',
-          'flask>=1.1.1'
+          'flask>=1.1.1',
           'flask-cors',
           'flask-socketio',
           'graphviz',
           'multiprocessing_on_dill',
           'networkx',
           'numba',
-          'numpy==1.18.4'
+          'numpy==1.18.4',
           'pandas>=0.24',
           'prettytable',
           'pymc3',


### PR DESCRIPTION
The following command failed due to missing commas in the file setup.py:
```
python setup.py install
```