### PR TITLE
Add 'spflow' as package dependency

### DIFF
--- a/mb-data-pkg/setup.py
+++ b/mb-data-pkg/setup.py
@@ -23,6 +23,7 @@ setup(name='mb-data',
             'mb-modelbase',
             'numpy',
             'pandas',
+            'spflow'
       ],
       namespace_packages=['mb'],
       zip_safe=False,


### PR DESCRIPTION
Hei, 

small fix in the setup.py of the mb-data-pkg sub-directory. Missing packages was added: 'spflow'.

Best,

Eric